### PR TITLE
refactor var2static

### DIFF
--- a/foundrytools/core/font.py
+++ b/foundrytools/core/font.py
@@ -10,8 +10,6 @@ from fontTools.misc.cliTools import makeOutputFileName
 from fontTools.pens.statisticsPen import StatisticsPen
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.scaleUpem import scale_upem
-from fontTools.ttLib.tables._f_v_a_r import NamedInstance
-from fontTools.varLib.instancer import OverlapMode, instantiateVariableFont
 
 from foundrytools import constants as const
 from foundrytools.core.tables import (
@@ -838,35 +836,6 @@ class Font:  # pylint: disable=too-many-public-methods, too-many-instance-attrib
             raise FontConversionError("Font is already a SFNT font.")
         self.ttfont.flavor = None
 
-    def to_static(self, instance: NamedInstance, update_font_names: bool = True) -> TTFont:
-        """
-        Create a static instance from a variable font.
-
-        :param instance: A named instance with axis values.
-        :type instance: NamedInstance
-        :param update_font_names: If ``True``, update the font names in the static instance.
-        :type update_font_names: bool
-        :return: A static instance of the font.
-        :rtype: TTFont
-        """
-        if self.is_static:
-            raise FontConversionError("Font is already a static font.")
-
-        try:
-            self.fvar.check_instance_axes(instance)
-            self.fvar.check_instance_coordinates(instance)
-        except Exception as e:
-            raise FontConversionError(str(e)) from e
-
-        return instantiateVariableFont(
-            self.ttfont,
-            axisLimits=instance.coordinates,
-            inplace=False,
-            optimize=True,
-            overlap=OverlapMode.REMOVE_AND_IGNORE_ERRORS,
-            updateFontNames=update_font_names,
-        )
-
     def scale_upm(self, target_upm: int) -> None:
         """
         Scale the font to the specified Units Per Em (UPM) value.
@@ -897,7 +866,7 @@ class Font:  # pylint: disable=too-many-public-methods, too-many-instance-attrib
         direction of contours.
 
         This tool is an implementation of the ``removeOverlaps`` function in the ``fontTools``
-        library to add support for correcting contours windings and removing tiny paths.
+        library to add support for correcting contours winding and removing tiny paths.
 
         If one or more contours are modified, the glyf or CFF table will be rebuilt.
         If no contours are modified, the font will remain unchanged and the method will return an

--- a/foundrytools/core/tables/fvar.py
+++ b/foundrytools/core/tables/fvar.py
@@ -1,12 +1,8 @@
 from fontTools.ttLib import TTFont
-from fontTools.ttLib.tables._f_v_a_r import NamedInstance, table__f_v_a_r
+from fontTools.ttLib.tables._f_v_a_r import table__f_v_a_r
 
-from foundrytools.constants import T_FVAR, T_NAME
+from foundrytools.constants import T_FVAR
 from foundrytools.core.tables.default import DefaultTbl
-
-
-class BadInstanceError(Exception):
-    """Raised if the instance is invalid."""
 
 
 class FvarTable(DefaultTbl):  # pylint: disable=too-few-public-methods
@@ -40,114 +36,3 @@ class FvarTable(DefaultTbl):  # pylint: disable=too-few-public-methods
         :type value: table__k_e_r_n
         """
         self._table = value
-
-    def check_instance_axes(self, instance: NamedInstance) -> None:
-        """
-        Check if a NamedInstance has valid axes for the font.
-
-        :param instance: The named instance.
-        :type instance: NamedInstance
-        :raises BadInstanceError: If the instance axes are invalid.
-        """
-        if sorted(instance.coordinates.keys()) != sorted(self.get_axes_tags()):
-            raise BadInstanceError(
-                f"Instance axes ({sorted(instance.coordinates.keys())}) do not match the font axes "
-                f"({sorted(self.get_axes_tags())})."
-            )
-
-    def check_instance_coordinates(self, instance: NamedInstance) -> None:
-        """
-        Check a NamedInstance's coordinates against the font's axis limits.
-
-        :param instance: The named instance.
-        :type instance: NamedInstance
-        :raises BadInstanceError: If the instance coordinates are invalid.
-        """
-        for axis, value in instance.coordinates.items():
-            if not self.get_axis_limits(axis)[0] <= value <= self.get_axis_limits(axis)[1]:
-                raise BadInstanceError(
-                    f"Invalid value for axis '{axis}': {value}"
-                    f" (allowed range: {self.get_axis_limits(axis)[0]} to "
-                    f"{self.get_axis_limits(axis)[1]})"
-                )
-
-    def get_axes_tags(self) -> list[str]:
-        """
-        Returns the axis tags of the font.
-
-        :return: The axis tags of the font.
-        :rtype: list
-        """
-        return [axis.axisTag for axis in self.table.axes]
-
-    def get_axis_limits(self, axis_tag: str) -> tuple[float, float]:
-        """
-        Returns the minimum and maximum values of an axis.
-
-        :param axis_tag: The axis tag.
-        :type axis_tag: str
-        :return: The limits of the axis.
-        :rtype: tuple[float, float]
-        """
-        # Set 'hidden' to True because we don't know if the axis tag belongs to a hidden axis
-        for axis in self.table.axes:
-            if axis.axisTag == axis_tag:
-                return axis.minValue, axis.maxValue
-
-        raise ValueError(f"Axis '{axis_tag}' not found.")
-
-    @staticmethod
-    def get_fallback_subfamily_name(instance: NamedInstance) -> str:
-        """
-        Get the fallback subfamily name for a NamedInstance object.
-
-        :param instance: The NamedInstance object.
-        :type instance: NamedInstance
-        :return: The fallback subfamily name.
-        :rtype: str
-        """
-        return "_".join([f"{k}_{v}" for k, v in instance.coordinates.items()])
-
-    def get_fallback_postscript_name(self, instance: NamedInstance) -> str:
-        """
-        Get the fallback PostScript name for a NamedInstance object.
-
-        :param instance: The NamedInstance object.
-        :type instance: NamedInstance
-        :return: The fallback PostScript name.
-        :rtype: str
-        """
-        family_name = str(self.ttfont[T_NAME].getBestFamilyName())  # cast to str to handle None
-        subfamily_name = self.get_fallback_subfamily_name(instance)
-        return f"{family_name}-{subfamily_name}".replace(" ", "").replace(".", "_")
-
-    def get_instance_postscript_name(self, instance: NamedInstance) -> str:
-        """
-        Get the PostScript name of a NamedInstance object.
-
-        :param instance: The NamedInstance object.
-        :type instance: NamedInstance
-        :return: The PostScript name.
-        :rtype: str
-        """
-        if instance.postscriptNameID < 65535:
-            postscript_name = self.ttfont[T_NAME].getDebugName(instance.postscriptNameID)
-            if postscript_name:
-                return postscript_name
-        return self.get_fallback_postscript_name(instance)
-
-    def get_named_or_custom_instance(self, instance: NamedInstance) -> tuple[bool, NamedInstance]:
-        """
-        Returns a named instance if the instance coordinates are the same, otherwise the custom
-        instance.
-
-        :param instance: The named instance.
-        :type instance: NamedInstance
-        :return: A tuple with a boolean indicating if the instance is named and the instance object.
-        :rtype: tuple[bool, NamedInstance]
-        """
-        for named_instance in self.table.instances:
-            if named_instance.coordinates == instance.coordinates:
-                return True, named_instance
-
-        return False, instance


### PR DESCRIPTION
This pull request includes significant changes to the `foundrytools` package, focusing on the refactoring of the variable font to static font conversion process. The most important changes involve the removal of redundant methods, the introduction of new error handling, and enhancements to the name table update process.

Refactoring and Code Simplification:

* [`foundrytools/app/var2static.py`](diffhunk://#diff-b28c0265cc0a3b6e139c3408d011d3a79fe229616c54827bf7f38c79ab3a0c73L1-L9): Replaced the `to_static` method with a new `create_static_instance` function and removed the `logger` import. Introduced the `get_existing_instance` function to check for existing instances and updated the `run` function to use these new methods. [[1]](diffhunk://#diff-b28c0265cc0a3b6e139c3408d011d3a79fe229616c54827bf7f38c79ab3a0c73L1-L9) [[2]](diffhunk://#diff-b28c0265cc0a3b6e139c3408d011d3a79fe229616c54827bf7f38c79ab3a0c73L29-R81) [[3]](diffhunk://#diff-b28c0265cc0a3b6e139c3408d011d3a79fe229616c54827bf7f38c79ab3a0c73L89-R175)
* [`foundrytools/core/font.py`](diffhunk://#diff-ad86fa7c0b9ab39d2d7450dd4b590db96336080a801fe1fa6305e973262ae2f8L841-L869): Removed the `to_static` method and its associated checks for instance axes and coordinates.

Error Handling Improvements:

* [`foundrytools/app/var2static.py`](diffhunk://#diff-b28c0265cc0a3b6e139c3408d011d3a79fe229616c54827bf7f38c79ab3a0c73R15-R18): Added a new `BadInstanceError` class for handling invalid instances. Updated the `run` function to raise `BadInstanceError` if instance coordinates are out of bounds. [[1]](diffhunk://#diff-b28c0265cc0a3b6e139c3408d011d3a79fe229616c54827bf7f38c79ab3a0c73R15-R18) [[2]](diffhunk://#diff-b28c0265cc0a3b6e139c3408d011d3a79fe229616c54827bf7f38c79ab3a0c73L89-R175)

Enhancements to Name Table Updates:

* [`foundrytools/app/var2static.py`](diffhunk://#diff-b28c0265cc0a3b6e139c3408d011d3a79fe229616c54827bf7f38c79ab3a0c73L52-R101): Improved the `update_name_table` function to handle cases where `InstantiateVariableFont` cannot update the name table. Modified the `run` function to generate a more descriptive `postscript_name` and update the name table accordingly. [[1]](diffhunk://#diff-b28c0265cc0a3b6e139c3408d011d3a79fe229616c54827bf7f38c79ab3a0c73L52-R101) [[2]](diffhunk://#diff-b28c0265cc0a3b6e139c3408d011d3a79fe229616c54827bf7f38c79ab3a0c73L62-R124)

Removal of Redundant Methods:

* [`foundrytools/core/tables/fvar.py`](diffhunk://#diff-cf1b3a94a4c4eb2dd5e1c134a4034aa23ff46f53fd23d503be862457aba24618L43-L153): Removed methods related to instance axis checks, coordinate validation, and fallback name generation, as these are now handled elsewhere.

These changes streamline the code, improve error handling, and ensure that the name table is correctly updated during the conversion process.