### PR TITLE
[check_update_name_table]: update docstring

### DIFF
--- a/foundrytools/app/var2static.py
+++ b/foundrytools/app/var2static.py
@@ -21,6 +21,9 @@ def check_update_name_table(var_font: Font) -> None:
     """
     Check if the name table can be updated when creating a static instance.
 
+    This method should be called once by third-party applications before starting the conversion
+    process. Calling it at every iteration is not necessary and slows down the process.
+
     :param var_font: The variable font to check and update.
     :type var_font: Font
     :raises UpdateNameTableError: If the 'STAT' table, Axis Values, or named instances are missing,


### PR DESCRIPTION
This pull request includes a small but important update to the `check_update_name_table` method in the `foundrytools/app/var2static.py` file. The change adds documentation to clarify the method's usage and improve performance by advising against unnecessary calls.

Documentation improvement:

* [`foundrytools/app/var2static.py`](diffhunk://#diff-b28c0265cc0a3b6e139c3408d011d3a79fe229616c54827bf7f38c79ab3a0c73R24-R26): Added a note to the `check_update_name_table` method's docstring to indicate that it should be called once by third-party applications before starting the conversion process to avoid slowing down the process.