### PR TITLE
refactor table names

### DIFF
--- a/foundrytools/app/fix_empty_notdef.py
+++ b/foundrytools/app/fix_empty_notdef.py
@@ -137,27 +137,27 @@ def run(font: Font) -> bool:
             logger.warning("The '.notdef' glyph is not empty")
             return False
 
-        width = otRound(font.head.units_per_em / 1000 * WIDTH_CONSTANT)
+        width = otRound(font.t_head.units_per_em / 1000 * WIDTH_CONSTANT)
         height = width * HEIGHT_CONSTANT
         thickness = otRound(width / THICKNESS_CONSTANT)
 
         if font.is_ps:
             cs_width = (
                 None
-                if width == font.cff.private_dict.defaultWidthX
-                else width - font.cff.private_dict.nominalWidthX
+                if width == font.t_cff_.private_dict.defaultWidthX
+                else width - font.t_cff_.private_dict.nominalWidthX
             )
             charstring = draw_notdef_cff(
                 font=font, width=width, height=height, thickness=thickness, cs_width=cs_width
             )
             charstring.compile()
-            font.cff.top_dict.CharStrings[NOTDEF].setBytecode(charstring.bytecode)
+            font.t_cff_.top_dict.CharStrings[NOTDEF].setBytecode(charstring.bytecode)
 
         if font.is_tt:
             glyph = draw_notdef_glyf(font=font, width=width, height=height, thickness=thickness)
-            font.glyf.table[NOTDEF] = glyph
+            font.t_glyf.table[NOTDEF] = glyph
 
-        font.hmtx.table[NOTDEF] = (width, 0)
+        font.t_hmtx.table[NOTDEF] = (width, 0)
 
         return True
 

--- a/foundrytools/app/fix_italic_angle.py
+++ b/foundrytools/app/fix_italic_angle.py
@@ -38,14 +38,14 @@ def run(
     try:
         is_italic = font.flags.is_italic
         is_oblique = font.flags.is_oblique
-        post_italic_angle = font.post.italic_angle
-        hhea_run_rise = (font.hhea.caret_slope_run, font.hhea.caret_slope_rise)
-        run_rise_angle = font.hhea.run_rise_angle
+        post_italic_angle = font.t_post.italic_angle
+        hhea_run_rise = (font.t_hhea.caret_slope_run, font.t_hhea.caret_slope_rise)
+        run_rise_angle = font.t_hhea.run_rise_angle
 
         # Calculate the italic angle and the caret slope run and rise values.
         calculated_slant = font.calc_italic_angle(min_slant=min_slant)
-        calculated_run = font.hhea.calc_caret_slope_run(italic_angle=calculated_slant)
-        calculated_rise = font.hhea.calc_caret_slope_rise(italic_angle=calculated_slant)
+        calculated_run = font.t_hhea.calc_caret_slope_run(italic_angle=calculated_slant)
+        calculated_rise = font.t_hhea.calc_caret_slope_rise(italic_angle=calculated_slant)
 
         # Check if the ``is_italic`` attribute is correctly set.
         should_be_italic = italic and calculated_slant != 0.0
@@ -60,7 +60,7 @@ def run(
 
         # Check if the ``is_oblique`` attribute is correctly set. The oblique bit is only
         # defined in ``OS/2`` table version 4 and later.
-        should_be_oblique = oblique and calculated_slant != 0.0 and font.os_2.version >= 4
+        should_be_oblique = oblique and calculated_slant != 0.0 and font.t_os_2.version >= 4
         oblique_bit_check = is_oblique == should_be_oblique
         if not oblique_bit_check:
             font.flags.is_oblique = should_be_oblique
@@ -73,7 +73,7 @@ def run(
         # Check if the italic is correctly set in the ``post`` table.
         italic_angle_check = otRound(post_italic_angle) == otRound(calculated_slant)
         if not italic_angle_check:
-            font.post.italic_angle = calculated_slant
+            font.t_post.italic_angle = calculated_slant
         result["italic_angle"] = {
             "old": post_italic_angle,
             "new": calculated_slant,
@@ -83,8 +83,8 @@ def run(
         # Check if the run/rise values are correctly set in the ``hhea`` table.
         run_rise_check = otRound(run_rise_angle) == otRound(calculated_slant)
         if not run_rise_check:
-            font.hhea.caret_slope_run = calculated_run
-            font.hhea.caret_slope_rise = calculated_rise
+            font.t_hhea.caret_slope_run = calculated_run
+            font.t_hhea.caret_slope_rise = calculated_rise
         result["run_rise"] = {
             "old": hhea_run_rise,
             "new": (calculated_run, calculated_rise),
@@ -92,10 +92,10 @@ def run(
         }
 
         if font.is_ps:
-            cff_italic_angle = font.cff.top_dict.ItalicAngle
+            cff_italic_angle = font.t_cff_.top_dict.ItalicAngle
             cff_italic_angle_check = otRound(cff_italic_angle) == otRound(calculated_slant)
             if not cff_italic_angle_check:
-                font.cff.top_dict.ItalicAngle = otRound(calculated_slant)
+                font.t_cff_.top_dict.ItalicAngle = otRound(calculated_slant)
             result["cff_italic_angle"] = {
                 "old": cff_italic_angle,
                 "new": calculated_slant,

--- a/foundrytools/app/fix_monospace.py
+++ b/foundrytools/app/fix_monospace.py
@@ -24,7 +24,7 @@ def _get_glyph_metrics_stats(font: Font) -> dict[str, Union[bool, int]]:
     :return: A dictionary containing the metrics.
     :rtype: dict[str, Union[bool, int]]
     """
-    glyph_metrics = font.hmtx.table.metrics
+    glyph_metrics = font.t_hmtx.table.metrics
     # NOTE: `range(a, b)` includes `a` and does not include `b`.
     #       Here we don't include 0-31 as well as 127
     #       because these are control characters.
@@ -53,7 +53,7 @@ def _get_glyph_metrics_stats(font: Font) -> dict[str, Union[bool, int]]:
             if unicodedata.category(chr(value)).startswith(("L", "M", "N", "P", "S", "Zs")):
                 relevant_glyph_names.add(name)
         # Remove character glyphs that are mark glyphs.
-        gdef = font.gdef.table
+        gdef = font.t_gdef.table
         if gdef and gdef.table.GlyphClassDef:
             marks = {name for name, c in gdef.table.GlyphClassDef.classDefs.items() if c == 3}
             relevant_glyph_names.difference_update(marks)
@@ -93,15 +93,15 @@ def run(font: Font) -> bool:
         width_max = glyph_metrics["width_max"]
 
         if seems_monospaced:
-            font.post.fixed_pitch = True
-            font.os_2.table.panose.bFamilyType = 2
-            font.os_2.table.panose.bProportion = 9
-            font.hhea.advance_width_max = width_max
+            font.t_post.fixed_pitch = True
+            font.t_os_2.table.panose.bFamilyType = 2
+            font.t_os_2.table.panose.bProportion = 9
+            font.t_hhea.advance_width_max = width_max
 
-            modified = font.os_2.is_modified or font.post.is_modified or font.hhea.is_modified
+            modified = font.t_os_2.is_modified or font.t_post.is_modified or font.t_hhea.is_modified
 
-            if font.is_ps and not font.cff.top_dict.isFixedPitch:
-                font.cff.top_dict.isFixedPitch = True
+            if font.is_ps and not font.t_cff_.top_dict.isFixedPitch:
+                font.t_cff_.top_dict.isFixedPitch = True
                 modified = True
 
             return modified

--- a/foundrytools/app/otf_check_outlines.py
+++ b/foundrytools/app/otf_check_outlines.py
@@ -28,7 +28,7 @@ def run(font: Font, drop_hinting_data: bool = False) -> bool:
         with restore_flavor(font.ttfont):
             # Make a copy of the hinting data before checking the outlines, in case we need to
             # restore it later.
-            hinthing_data = font.cff.get_hinting_data() if not drop_hinting_data else None
+            hinthing_data = font.t_cff_.get_hinting_data() if not drop_hinting_data else None
 
             font.save(font.temp_file)
             checkoutlinesufo.run(args=[font.temp_file.as_posix(), "--error-correction-mode"])
@@ -37,7 +37,7 @@ def run(font: Font, drop_hinting_data: bool = False) -> bool:
 
             if hinthing_data and not drop_hinting_data:
                 font.reload()  # DO NOT REMOVE
-                font.cff.set_hinting_data(**hinthing_data)
+                font.t_cff_.set_hinting_data(**hinthing_data)
 
             return True
 

--- a/foundrytools/app/otf_dehint.py
+++ b/foundrytools/app/otf_dehint.py
@@ -21,7 +21,7 @@ def run(font: Font, drop_hinting_data: bool = False) -> bool:
         raise NotImplementedError("Not a PostScript font.")
 
     try:
-        font.cff.remove_hinting(drop_hinting_data=drop_hinting_data)
+        font.t_cff_.remove_hinting(drop_hinting_data=drop_hinting_data)
         return True
     except Exception as e:
         raise OTFDehintError(e) from e

--- a/foundrytools/app/remove_unused_glyphs.py
+++ b/foundrytools/app/remove_unused_glyphs.py
@@ -19,7 +19,7 @@ def run(font: Font) -> set[str]:
         options = Options(**SUBSETTER_DEFAULTS)
         options.recalc_timestamp = font.ttfont.recalcTimestamp
         old_glyph_order = font.ttfont.getGlyphOrder()
-        unicodes = font.cmap.get_all_codepoints()
+        unicodes = font.t_cmap.get_all_codepoints()
         subsetter = Subsetter(options=options)
         subsetter.populate(unicodes=unicodes)
         subsetter.subset(font.ttfont)

--- a/foundrytools/app/rename_glyph.py
+++ b/foundrytools/app/rename_glyph.py
@@ -38,7 +38,7 @@ def run(font: Font, old_name: str, new_name: str) -> bool:
 
         rename_map = dict(zip(old_glyph_order, new_glyph_order))
         PostProcessor.rename_glyphs(otf=font.ttfont, rename_map=rename_map)
-        font.cmap.rebuild_character_map(remap_all=True)
+        font.t_cmap.rebuild_character_map(remap_all=True)
 
         return new_glyph_order != old_glyph_order
 

--- a/foundrytools/app/rename_glyphs.py
+++ b/foundrytools/app/rename_glyphs.py
@@ -25,7 +25,7 @@ def run(font: Font, new_glyph_order: list[str]) -> bool:
             return False
         rename_map = dict(zip(old_glyph_order, new_glyph_order))
         PostProcessor.rename_glyphs(otf=font.ttfont, rename_map=rename_map)
-        font.cmap.rebuild_character_map(remap_all=True)
+        font.t_cmap.rebuild_character_map(remap_all=True)
 
         return True
 

--- a/foundrytools/app/set_production_names.py
+++ b/foundrytools/app/set_production_names.py
@@ -26,7 +26,7 @@ def run(font: Font) -> list[tuple[str, str]]:
 
     try:
         old_glyph_order: list[str] = font.ttfont.getGlyphOrder()
-        reversed_cmap = font.cmap.table.buildReversed()
+        reversed_cmap = font.t_cmap.table.buildReversed()
         new_glyph_order: list[str] = []
         renamed_glyphs: list[tuple[str, str]] = []
 
@@ -57,7 +57,7 @@ def run(font: Font) -> list[tuple[str, str]]:
 
         rename_map = dict(zip(old_glyph_order, new_glyph_order))
         PostProcessor.rename_glyphs(otf=font.ttfont, rename_map=rename_map)
-        font.cmap.rebuild_character_map(remap_all=True)
+        font.t_cmap.rebuild_character_map(remap_all=True)
 
         return renamed_glyphs
 

--- a/foundrytools/app/ttf_autohint.py
+++ b/foundrytools/app/ttf_autohint.py
@@ -30,7 +30,7 @@ def run(font: Font) -> bool:
             font.save(buffer, reorder_tables=None)
             data = ttfautohint(in_buffer=buffer.getvalue(), no_info=True)
             hinted_font = TTFont(BytesIO(data), recalcTimestamp=False)
-            hinted_font[T_HEAD].modified = font.head.modified_timestamp
+            hinted_font[T_HEAD].modified = font.t_head.modified_timestamp
             font.ttfont = hinted_font
             font.ttfont.flavor = flavor
             return True

--- a/foundrytools/core/font.py
+++ b/foundrytools/core/font.py
@@ -134,13 +134,13 @@ class StyleFlags:
         regular: Optional[bool] = None,
     ) -> None:
         if bold is not None:
-            self.font.os_2.fs_selection.bold = bold
-            self.font.head.mac_style.bold = bold
+            self.font.t_os_2.fs_selection.bold = bold
+            self.font.t_head.mac_style.bold = bold
         if italic is not None:
-            self.font.os_2.fs_selection.italic = italic
-            self.font.head.mac_style.italic = italic
+            self.font.t_os_2.fs_selection.italic = italic
+            self.font.t_head.mac_style.italic = italic
         if regular is not None:
-            self.font.os_2.fs_selection.regular = regular
+            self.font.t_os_2.fs_selection.regular = regular
 
     @property
     def is_bold(self) -> bool:
@@ -156,7 +156,7 @@ class StyleFlags:
         :rtype: bool
         """
         try:
-            return self.font.os_2.fs_selection.bold and self.font.head.mac_style.bold
+            return self.font.t_os_2.fs_selection.bold and self.font.t_head.mac_style.bold
         except Exception as e:
             raise FontError("An error occurred while checking if the font is bold") from e
 
@@ -179,7 +179,7 @@ class StyleFlags:
         :rtype: bool
         """
         try:
-            return self.font.os_2.fs_selection.italic and self.font.head.mac_style.italic
+            return self.font.t_os_2.fs_selection.italic and self.font.t_head.mac_style.italic
         except Exception as e:
             raise FontError("An error occurred while checking if the font is italic") from e
 
@@ -197,7 +197,7 @@ class StyleFlags:
         :rtype: bool
         """
         try:
-            return self.font.os_2.fs_selection.oblique
+            return self.font.t_os_2.fs_selection.oblique
         except Exception as e:
             raise FontError("An error occurred while checking if the font is oblique") from e
 
@@ -205,7 +205,7 @@ class StyleFlags:
     def is_oblique(self, value: bool) -> None:
         """Set the oblique bit in the OS/2 table."""
         try:
-            self.font.os_2.fs_selection.oblique = value
+            self.font.t_os_2.fs_selection.oblique = value
         except Exception as e:
             raise FontError("An error occurred while setting the oblique bit") from e
 
@@ -218,7 +218,7 @@ class StyleFlags:
         :rtype: bool
         """
         try:
-            return self.font.os_2.fs_selection.regular
+            return self.font.t_os_2.fs_selection.regular
         except Exception as e:
             raise FontError("An error occurred while checking if the font is regular") from e
 
@@ -230,7 +230,7 @@ class StyleFlags:
                 self._set_font_style(regular=True, bold=False, italic=False)
             else:
                 # Prevent setting the regular bit if the font is bold or italic
-                self.font.os_2.fs_selection.regular = not (self.is_bold or self.is_italic)
+                self.font.t_os_2.fs_selection.regular = not (self.is_bold or self.is_italic)
 
 
 class Font:  # pylint: disable=too-many-public-methods, too-many-instance-attributes
@@ -449,7 +449,7 @@ class Font:  # pylint: disable=too-many-public-methods, too-many-instance-attrib
         return self._temp_file
 
     @property
-    def cff(self) -> CFFTable:
+    def t_cff_(self) -> CFFTable:
         """
         The ``CFF `` table handler.
 
@@ -459,7 +459,7 @@ class Font:  # pylint: disable=too-many-public-methods, too-many-instance-attrib
         return self._get_table(const.T_CFF)
 
     @property
-    def cmap(self) -> CmapTable:
+    def t_cmap(self) -> CmapTable:
         """
         The ``cmap`` table handler.
 
@@ -469,7 +469,7 @@ class Font:  # pylint: disable=too-many-public-methods, too-many-instance-attrib
         return self._get_table(const.T_CMAP)
 
     @property
-    def fvar(self) -> FvarTable:
+    def t_fvar(self) -> FvarTable:
         """
         The ``fvar`` table handler.
 
@@ -479,7 +479,7 @@ class Font:  # pylint: disable=too-many-public-methods, too-many-instance-attrib
         return self._get_table(const.T_FVAR)
 
     @property
-    def gdef(self) -> GdefTable:
+    def t_gdef(self) -> GdefTable:
         """
         The ``GDEF`` table handler.
 
@@ -489,7 +489,7 @@ class Font:  # pylint: disable=too-many-public-methods, too-many-instance-attrib
         return self._get_table(const.T_GDEF)
 
     @property
-    def glyf(self) -> GlyfTable:
+    def t_glyf(self) -> GlyfTable:
         """
         The ``glyf`` table handler.
 
@@ -499,7 +499,7 @@ class Font:  # pylint: disable=too-many-public-methods, too-many-instance-attrib
         return self._get_table(const.T_GLYF)
 
     @property
-    def gsub(self) -> GsubTable:
+    def t_gsub(self) -> GsubTable:
         """
         The ``GSUB`` table handler.
 
@@ -509,7 +509,7 @@ class Font:  # pylint: disable=too-many-public-methods, too-many-instance-attrib
         return self._get_table(const.T_GSUB)
 
     @property
-    def head(self) -> HeadTable:
+    def t_head(self) -> HeadTable:
         """
         The ``head`` table handler.
 
@@ -519,7 +519,7 @@ class Font:  # pylint: disable=too-many-public-methods, too-many-instance-attrib
         return self._get_table(const.T_HEAD)
 
     @property
-    def hhea(self) -> HheaTable:
+    def t_hhea(self) -> HheaTable:
         """
         The ``hhea`` table handler.
 
@@ -529,7 +529,7 @@ class Font:  # pylint: disable=too-many-public-methods, too-many-instance-attrib
         return self._get_table(const.T_HHEA)
 
     @property
-    def hmtx(self) -> HmtxTable:
+    def t_hmtx(self) -> HmtxTable:
         """
         The ``hmtx`` table handler.
 
@@ -539,7 +539,7 @@ class Font:  # pylint: disable=too-many-public-methods, too-many-instance-attrib
         return self._get_table(const.T_HMTX)
 
     @property
-    def kern(self) -> KernTable:
+    def t_kern(self) -> KernTable:
         """
         The ``kern`` table handler.
 
@@ -549,7 +549,7 @@ class Font:  # pylint: disable=too-many-public-methods, too-many-instance-attrib
         return self._get_table(const.T_KERN)
 
     @property
-    def name(self) -> NameTable:
+    def t_name(self) -> NameTable:
         """
         The ``name`` table handler.
 
@@ -559,7 +559,7 @@ class Font:  # pylint: disable=too-many-public-methods, too-many-instance-attrib
         return self._get_table(const.T_NAME)
 
     @property
-    def os_2(self) -> OS2Table:
+    def t_os_2(self) -> OS2Table:
         """
         The ``OS/2`` table handler.
 
@@ -569,7 +569,7 @@ class Font:  # pylint: disable=too-many-public-methods, too-many-instance-attrib
         return self._get_table(const.T_OS_2)
 
     @property
-    def post(self) -> PostTable:
+    def t_post(self) -> PostTable:
         """
         The ``post`` table handler.
 
@@ -821,14 +821,14 @@ class Font:  # pylint: disable=too-many-public-methods, too-many-instance-attrib
             raise FontConversionError(
                 "Conversion to PostScript is not supported for variable fonts."
             )
-        self.glyf.decompose_all()
+        self.t_glyf.decompose_all()
 
         charstrings = quadratics_to_cubics(
             font=self.ttfont, tolerance=tolerance, correct_contours=correct_contours
         )
         build_otf(font=self.ttfont, charstrings_dict=charstrings)
 
-        self.os_2.recalc_avg_char_width()
+        self.t_os_2.recalc_avg_char_width()
 
     def to_sfnt(self) -> None:
         """Convert a font to SFNT."""
@@ -849,7 +849,7 @@ class Font:  # pylint: disable=too-many-public-methods, too-many-instance-attrib
                 f"units_per_em must be in the range {const.MAX_UPM} to {const.MAX_UPM}."
             )
 
-        if self.head.units_per_em == target_upm:
+        if self.t_head.units_per_em == target_upm:
             return
 
         scale_upem(self.ttfont, new_upem=target_upm)
@@ -895,14 +895,14 @@ class Font:  # pylint: disable=too-many-public-methods, too-many-instance-attrib
             raise NotImplementedError("Contour correction is not supported for variable fonts.")
 
         if self.is_ps:
-            return self.cff.correct_contours(
+            return self.t_cff_.correct_contours(
                 remove_hinting=remove_hinting,
                 ignore_errors=ignore_errors,
                 remove_unused_subroutines=remove_unused_subroutines,
                 min_area=min_area,
             )
         if self.is_tt:
-            return self.glyf.correct_contours(
+            return self.t_glyf.correct_contours(
                 remove_hinting=remove_hinting,
                 ignore_errors=ignore_errors,
                 min_area=min_area,

--- a/foundrytools/core/tables/gsub.py
+++ b/foundrytools/core/tables/gsub.py
@@ -84,7 +84,7 @@ class GsubTable(DefaultTbl):  # pylint: disable=too-few-public-methods
 
         >>> from foundrytools import Font
         >>> font = Font("path/to/font.ttf")
-        >>> font.gsub.rename_feature("smcp", "ss20")
+        >>> font.t_gsub.rename_feature("smcp", "ss20")
         >>> font.save("path/to/font.ttf")
 
         :param feature_tag: The feature tag to rename.


### PR DESCRIPTION
This pull request includes changes to the `foundrytools` package to update the font attribute references throughout the codebase. The changes primarily involve updating the references to font table attributes to use a new naming convention, which prefixes the attributes with `t_`.

The most important changes include:

### Updates to Font Attribute References:

* [`foundrytools/app/fix_empty_notdef.py`](diffhunk://#diff-bf48f0bfc3540465163dcc693e59a3de8a3aea7b375cfafeed5e4b12618b9623L140-R160): Updated references to `font.head`, `font.cff`, `font.glyf`, and `font.hmtx` to use `font.t_head`, `font.t_cff_`, `font.t_glyf`, and `font.t_hmtx` respectively.
* [`foundrytools/app/fix_italic_angle.py`](diffhunk://#diff-88449be4b222bc6fe0e934b9ee500e071c58295c81e40ef2a80bc7ece38c8e10L41-R48): Updated references to `font.post`, `font.hhea`, and `font.os_2` to use `font.t_post`, `font.t_hhea`, and `font.t_os_2` respectively. [[1]](diffhunk://#diff-88449be4b222bc6fe0e934b9ee500e071c58295c81e40ef2a80bc7ece38c8e10L41-R48) [[2]](diffhunk://#diff-88449be4b222bc6fe0e934b9ee500e071c58295c81e40ef2a80bc7ece38c8e10L63-R63) [[3]](diffhunk://#diff-88449be4b222bc6fe0e934b9ee500e071c58295c81e40ef2a80bc7ece38c8e10L76-R76) [[4]](diffhunk://#diff-88449be4b222bc6fe0e934b9ee500e071c58295c81e40ef2a80bc7ece38c8e10L86-R98)
* [`foundrytools/app/fix_monospace.py`](diffhunk://#diff-3a3fef7a3198632f69b5d72268fcd2c4154e7b405f49a4c5ac0d9f35ea949ed9L27-R27): Updated references to `font.hmtx`, `font.gdef`, `font.post`, `font.os_2`, and `font.hhea` to use `font.t_hmtx`, `font.t_gdef`, `font.t_post`, `font.t_os_2`, and `font.t_hhea` respectively. [[1]](diffhunk://#diff-3a3fef7a3198632f69b5d72268fcd2c4154e7b405f49a4c5ac0d9f35ea949ed9L27-R27) [[2]](diffhunk://#diff-3a3fef7a3198632f69b5d72268fcd2c4154e7b405f49a4c5ac0d9f35ea949ed9L56-R56) [[3]](diffhunk://#diff-3a3fef7a3198632f69b5d72268fcd2c4154e7b405f49a4c5ac0d9f35ea949ed9L96-R104)
* [`foundrytools/app/otf_check_outlines.py`](diffhunk://#diff-bc8d5eef83ffeefbeed16a5965ff07687694a5347b707db51cc54e7473252724L31-R31): Updated references to `font.cff` to use `font.t_cff_`. [[1]](diffhunk://#diff-bc8d5eef83ffeefbeed16a5965ff07687694a5347b707db51cc54e7473252724L31-R31) [[2]](diffhunk://#diff-bc8d5eef83ffeefbeed16a5965ff07687694a5347b707db51cc54e7473252724L40-R40)
* [`foundrytools/app/otf_dehint.py`](diffhunk://#diff-8df14f720069e1bcba0a2f2591940e8fc7bd64201d862cd934d9271a5edb895eL24-R24): Updated references to `font.cff` to use `font.t_cff_`.
* [`foundrytools/app/remove_unused_glyphs.py`](diffhunk://#diff-721a564637e17afd360cb838fc31f5754924eae6aee555b1add40bc4b05878efL22-R22): Updated references to `font.cmap` to use `font.t_cmap`.
* [`foundrytools/app/rename_glyph.py`](diffhunk://#diff-6d006f5e7395fb90ad62b2fca87fb8968b9bb45be46946b2e8c184cd4addf263L41-R41): Updated references to `font.cmap` to use `font.t_cmap`.
* [`foundrytools/app/rename_glyphs.py`](diffhunk://#diff-d0afef2f6b22741be0a10ac9b79b9c6cfa1c9bb9ea8371f90daf7ec4f6013fe5L28-R28): Updated references to `font.cmap` to use `font.t_cmap`.
* [`foundrytools/app/set_production_names.py`](diffhunk://#diff-e23802f3225e685dc16480ba070a4030bebc573efe9d632b489a5e35eaa4f61eL29-R29): Updated references to `font.cmap` to use `font.t_cmap`. [[1]](diffhunk://#diff-e23802f3225e685dc16480ba070a4030bebc573efe9d632b489a5e35eaa4f61eL29-R29) [[2]](diffhunk://#diff-e23802f3225e685dc16480ba070a4030bebc573efe9d632b489a5e35eaa4f61eL60-R60)
* [`foundrytools/app/ttf_autohint.py`](diffhunk://#diff-c2f1a9b8c23d6c8e0e33b850877f80432959a462dcbcb86451225248ff45c3c3L33-R33): Updated references to `font.head` to use `font.t_head`.
* [`foundrytools/app/var2static.py`](diffhunk://#diff-b28c0265cc0a3b6e139c3408d011d3a79fe229616c54827bf7f38c79ab3a0c73L35-R35): Updated references to `font.fvar`, `font.name`, and `font.gsub` to use `font.t_fvar`, `font.t_name`, and `font.t_gsub` respectively. [[1]](diffhunk://#diff-b28c0265cc0a3b6e139c3408d011d3a79fe229616c54827bf7f38c79ab3a0c73L35-R35) [[2]](diffhunk://#diff-b28c0265cc0a3b6e139c3408d011d3a79fe229616c54827bf7f38c79ab3a0c73L50-R50) [[3]](diffhunk://#diff-b28c0265cc0a3b6e139c3408d011d3a79fe229616c54827bf7f38c79ab3a0c73L75-R75) [[4]](diffhunk://#diff-b28c0265cc0a3b6e139c3408d011d3a79fe229616c54827bf7f38c79ab3a0c73L128-R150) [[5]](diffhunk://#diff-b28c0265cc0a3b6e139c3408d011d3a79fe229616c54827bf7f38c79ab3a0c73L165-R174) [[6]](diffhunk://#diff-b28c0265cc0a3b6e139c3408d011d3a79fe229616c54827bf7f38c79ab3a0c73L223-R223)
* [`foundrytools/core/font.py`](diffhunk://#diff-ad86fa7c0b9ab39d2d7450dd4b590db96336080a801fe1fa6305e973262ae2f8L137-R143): Updated references to `font.os_2` and `font.head` to use `font.t_os_2` and `font.t_head`. [[1]](diffhunk://#diff-ad86fa7c0b9ab39d2d7450dd4b590db96336080a801fe1fa6305e973262ae2f8L137-R143) [[2]](diffhunk://#diff-ad86fa7c0b9ab39d2d7450dd4b590db96336080a801fe1fa6305e973262ae2f8L159-R159) [[3]](diffhunk://#diff-ad86fa7c0b9ab39d2d7450dd4b590db96336080a801fe1fa6305e973262ae2f8L182-R182)