### PR TITLE
Refactor stem detection logic and add grouping functionality

### DIFF
--- a/foundrytools/app/otf_recalc_stems.py
+++ b/foundrytools/app/otf_recalc_stems.py
@@ -53,6 +53,7 @@ from afdko.otfautohint.report import Report
 
 __all__ = ["run"]
 
+
 def _get_report(
     file_path: Path, glyph_list: Optional[list[str]], report_all_stems: bool = False
 ) -> tuple[list[tuple[int, int, list[str]]], list[tuple[int, int, list[str]]]]:
@@ -168,7 +169,6 @@ def _get_first_n_stems(
             continue
         stem_snap.append(max_value)
     return sorted(stem_snap[:number_of_stems])
-
 
 
 def run(


### PR DESCRIPTION
This pull request includes significant updates to the `foundrytools/app/otf_recalc_stems.py` file, focusing on enhancing the functionality for recalculating stem values in font files. The changes introduce new functions for grouping widths, extracting representative stems, sorting groups, and generating reports. Additionally, the `run` function has been updated to orchestrate the entire recalculation process with more parameters and improved logic.

Enhancements to recalculation functionality:

* Added module-level docstring to describe the purpose and steps of the recalculation process.
* Introduced `_group_widths_with_neighbors` function to group report entries based on width proximity.
* Added `_get_first_n_stems` function to extract a specified number of representative stem values.
* Implemented `_sort_groups_by_count_sum` and `_sort_groups_by_max_count` functions to sort stem groups.
* Updated `run` function to include parameters for reporting all stems, maximum distance, and the number of horizontal and vertical stems to extract, and refactored the logic to use the new helper functions.Introduced new helper functions to streamline grouping and selection of stem values, enhancing code readability and maintainability. Replaced hardcoded glyph lists with dynamic reporting options and removed redundant logic for curved and straight stems. This improves flexibility and ensures results conform to technical recommendations for minimum stem value differences.