### PR TITLE
Dev

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 warn_unused_configs = True
 disallow_untyped_defs = True
-exclude = venv
+exclude = .venv
 
 [mypy-fontTools.*]
 ignore_missing_imports = True

--- a/foundrytools/constants.py
+++ b/foundrytools/constants.py
@@ -173,6 +173,3 @@ WINDOWS_ENCODING_IDS = {
     9: "Reserved",
     10: "UCS4",
 }
-
-
-TERMINAL_WIDTH = 120


### PR DESCRIPTION
Configuration update:

* [`.mypy.ini`](diffhunk://#diff-d32817eb7eb78022de4f700811f4e688d657456cb635c693c72966c6ac6c68c0L4-R4): Changed the `exclude` configuration from `venv` to `.venv` to correctly exclude the virtual environment directory.

Code cleanup:

* [`foundrytools/constants.py`](diffhunk://#diff-2ac0aa51ee8ee760f2f61898411f77bd96c05f64763cb09ae96413d1fceda494L176-L178): Removed unused constant `TERMINAL_WIDTH`.