### PR TITLE
Add defaults to 'remove_glyphs' signature

### DIFF
--- a/foundrytools/core/font.py
+++ b/foundrytools/core/font.py
@@ -1053,8 +1053,8 @@ class Font:  # pylint: disable=too-many-public-methods, too-many-instance-attrib
 
     def remove_glyphs(
         self,
-        glyph_names_to_remove: Optional[set[str]],
-        glyph_ids_to_remove: Optional[set[int]],
+        glyph_names_to_remove: Optional[set[str]] = None,
+        glyph_ids_to_remove: Optional[set[int]] = None,
     ) -> set[str]:
         """
         Removes glyphs from the font using the fontTools subsetter.


### PR DESCRIPTION
This pull request includes a small change to the `foundrytools/core/font.py` file. The change updates the `remove_glyphs` method to provide default values for its parameters.

* [`foundrytools/core/font.py`](diffhunk://#diff-ad86fa7c0b9ab39d2d7450dd4b590db96336080a801fe1fa6305e973262ae2f8L1056-R1057): Updated the `remove_glyphs` method to provide default values (`None`) for the `glyph_names_to_remove` and `glyph_ids_to_remove` parameters.