### PR TITLE
Check if the 'GSUB' table exists before retrieving UI name IDs

### DIFF
--- a/foundrytools/app/var2static.py
+++ b/foundrytools/app/var2static.py
@@ -141,6 +141,8 @@ def _remove_unused_names(static_font: Font) -> None:
     """
     The method ``removeUnusedNames`` is very slow. This should be enough for most cases.
     """
+    if not T_GSUB in static_font.ttfont:
+        return
     ui_name_ids = static_font.t_gsub.get_ui_name_ids()
     name_ids_to_remove = [
         name.nameID

--- a/foundrytools/app/var2static.py
+++ b/foundrytools/app/var2static.py
@@ -141,7 +141,7 @@ def _remove_unused_names(static_font: Font) -> None:
     """
     The method ``removeUnusedNames`` is very slow. This should be enough for most cases.
     """
-    if not T_GSUB in static_font.ttfont:
+    if T_GSUB not in static_font.ttfont:
         return
     ui_name_ids = static_font.t_gsub.get_ui_name_ids()
     name_ids_to_remove = [


### PR DESCRIPTION
This pull request includes a change to the `foundrytools/app/var2static.py` file to improve the performance of the `_remove_unused_names` function by adding a check for the presence of the `T_GSUB` table in the `static_font` object before proceeding with the rest of the method.

Performance improvement:

* [`foundrytools/app/var2static.py`](diffhunk://#diff-b28c0265cc0a3b6e139c3408d011d3a79fe229616c54827bf7f38c79ab3a0c73R144-R145): Added a check to ensure the `T_GSUB` table exists in `static_font.ttfont` before attempting to retrieve UI name IDs, preventing unnecessary operations if the table is not present.