### PR TITLE
Add method to delete a table from the font

### DIFF
--- a/foundrytools/core/font.py
+++ b/foundrytools/core/font.py
@@ -1275,3 +1275,16 @@ class Font:  # pylint: disable=too-many-public-methods, too-many-instance-attrib
         with restore_flavor(self.ttfont):
             desubroutinize(self.ttfont)
             return True
+
+    def del_table(self, table_tag: str) -> bool:
+        """
+        Delete a table from the font.
+
+        :param table_tag: The table tag.
+        :type table_tag: str
+        """
+        if table_tag not in self.ttfont.reader.tables:
+            return False
+
+        self.ttfont.reader.tables.pop(table_tag, None)
+        return True


### PR DESCRIPTION
This pull request includes a new method to the `foundrytools/core/font.py` file. The most important change is the addition of the `del_table` method, which allows for the deletion of a table from the font.

* [`foundrytools/core/font.py`](diffhunk://#diff-ad86fa7c0b9ab39d2d7450dd4b590db96336080a801fe1fa6305e973262ae2f8R1278-R1290): Added the `del_table` method to delete a table from the font based on the provided `table_tag`.