### PR TITLE
OS/2 additions

### DIFF
--- a/foundrytools/core/tables/os_2.py
+++ b/foundrytools/core/tables/os_2.py
@@ -886,9 +886,7 @@ class OS2Table(DefaultTbl):  # pylint: disable=too-many-public-methods, too-many
 
         if target_version == 5:
             self.us_lower_optical_point_size = 0
-            self.us_upper_optical_point_size = 65535 / 20
-            self.table.usLowerOpticalPointSize = 0
-            self.table.usUpperOpticalPointSize = 65535 / 20
+            self.us_upper_optical_point_size = int(65535 / 20)
 
         if target_version < 4:
             self.fs_selection.use_typo_metrics = False

--- a/foundrytools/core/tables/os_2.py
+++ b/foundrytools/core/tables/os_2.py
@@ -880,11 +880,13 @@ class OS2Table(DefaultTbl):  # pylint: disable=too-many-public-methods, too-many
         if current_version < 2:
             self.x_height = _get_glyph_height("x")
             self.cap_height = _get_glyph_height("H")
-            self.table.usDefaultChar = 0
-            self.table.usBreakChar = 32
+            self.us_default_char = 0
+            self.us_break_char = 32
             self.recalc_max_context()
 
         if target_version == 5:
+            self.us_lower_optical_point_size = 0
+            self.us_upper_optical_point_size = 65535 / 20
             self.table.usLowerOpticalPointSize = 0
             self.table.usUpperOpticalPointSize = 65535 / 20
 


### PR DESCRIPTION
This pull request updates variable names in `foundrytools/core/tables/os_2.py` to align with naming conventions and corrects a calculation to ensure type consistency.

Variable name updates:

* Replaced `self.table.usDefaultChar` with `self.us_default_char` and `self.table.usBreakChar` with `self.us_break_char` to improve naming consistency.

Type consistency correction:

* Changed the calculation of `self.us_upper_optical_point_size` to explicitly cast the result to an integer using `int(65535 / 20)` for type consistency.